### PR TITLE
Maintenance 2

### DIFF
--- a/tanks-game/_source/aaa_first.cpp
+++ b/tanks-game/_source/aaa_first.cpp
@@ -16,6 +16,7 @@
 //Linux continued: malloc.c says to include rpnew.h on Windows, and Linux does not compile if rpnew.h is included (redefining new/delete/etc), even though the readme implies it's supposed to be included despite the platform
 
 #define STB_IMAGE_IMPLEMENTATION
+#define STBI_ONLY_PNG
 #include <stb_image.h>
 
 FirstLoadedObject::FirstLoadedObject() {

--- a/tanks-game/_source/developer-manager.cpp
+++ b/tanks-game/_source/developer-manager.cpp
@@ -115,10 +115,10 @@ void DeveloperManager::devInsert(int x, int y) {
 	double* posArr;
 	switch (insertIndex) {
 		case 0:
-			#if _DEBUG
-			PowerupManager::pushPowerup(new PowerSquare(x, y, "dev", "colorless_longinvincible"));
-			#else
+			#ifdef NDEBUG
 			PowerupManager::pushPowerup(new PowerSquare(x, y, "dev", "longinvincible"));
+			#else
+			PowerupManager::pushPowerup(new PowerSquare(x, y, "dev", "colorless_longinvincible"));
 			#endif
 			break;
 		case 1:

--- a/tanks-game/_source/physics-handler.cpp
+++ b/tanks-game/_source/physics-handler.cpp
@@ -24,10 +24,10 @@ PhysicsHandler::SweepAndPruneTask::SweepAndPruneTask(uint32_t num_threads_) {
 	m_collisionLists = new std::vector<std::pair<int, int>>*[num_threads_];
 	for (int i = 0; i < num_threads_; i++) {
 		m_collisionLists[i] = new std::vector<std::pair<int, int>>;
-		#if _DEBUG
-		//performance seems about the same with or without reserving //TODO: check again
-		#else
+		#ifdef NDEBUG
 		m_collisionLists[i]->reserve(1024 * 1024 / 4); //random guess for what should be enough
+		#else
+		//performance seems about the same with or without reserving //TODO: check again
 		#endif
 	}
 }

--- a/tanks-game/_source/renderer.cpp
+++ b/tanks-game/_source/renderer.cpp
@@ -116,20 +116,20 @@ bool Renderer::Bullet_VertexData::enoughRoomForMoreBulletValues(unsigned int pus
 
 Renderer::MainBatched_VertexData::MainBatched_VertexData() {
 	m_shaderName = "main";
-	#if _DEBUG
-	//performance is awful //TODO: check again
-	#else
+	#ifdef NDEBUG
 	m_vertices.reserve(MainBatched_VertexData::maxVerticesDataLength);
 	m_indices.reserve(MainBatched_VertexData::maxIndicesDataLength);
+	#else
+	//performance is awful //TODO: check again
 	#endif
 }
 
 Renderer::Bullet_VertexData::Bullet_VertexData() {
 	m_shaderName = "bullet";
-	#if _DEBUG
-	//performance is awful //TODO: check again
-	#else
+	#ifdef NDEBUG
 	m_bulletValues.reserve(Bullet_VertexData::maxDataLength);
+	#else
+	//performance is awful //TODO: check again
 	#endif
 }
 


### PR DESCRIPTION
* swap `_DEBUG` uses for `NDEBUG`: now the Linux codepath is the same as Windows
* set stb_image to only PNG
    * stb_image is only used for the application icon. If desired, it could be removed entirely by embedding the decoded image in a source file.